### PR TITLE
build, fix check for MAP_ANON_NEEDS_DARWIN_SOURCE (issue #11)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,8 @@ SXE_LANG_WERROR([off])
 AC_CHECK_HEADERS([sys/mman.h])
 AC_MSG_CHECKING([for ANON maps])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _POSIX_C_SOURCE 200112
+#define _BSD_SOURCE
 #if defined HAVE_SYS_MMAN_H
 # include <sys/mman.h>
 #endif  /* HAVE_SYS_MMAN_H */
@@ -62,6 +64,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 ]])], [sxe_cv_feat_anon_maps="yes"], [sxe_cv_feat_anon_maps="no"])
 if test "${sxe_cv_feat_anon_maps}" = "no"; then
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#define _POSIX_C_SOURCE 200112
+#define _BSD_SOURCE
 #define _DARWIN_C_SOURCE
 #if defined HAVE_SYS_MMAN_H
 # include <sys/mman.h>


### PR DESCRIPTION
Without _POSIX_C_SOURCE we would find always MAP_ANON or MAP_ANONYMOUS.
But any Makefile.am has CPPFLAGS with -D_POSIX_C_SOURCE=200112L
and -D_BSD_SOURCE.
