### PR TITLE
build, include alloca.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ SXE_CHECK_CFLAGS
 AC_CHECK_HEADERS([endian.h sys/endian.h machine/endian.h byteorder.h])
 AC_CHECK_HEADERS([byteswap.h])
 
+AC_CHECK_HEADERS([alloca.h])
+
 ## disallow warnings from here
 SXE_LANG_WERROR([off])
 

--- a/lib/tzraw.c
+++ b/lib/tzraw.c
@@ -56,6 +56,10 @@
 #include <time.h>
 #include <limits.h>
 
+#if defined HAVE_ALLOCA_H
+# include <alloca.h>
+#endif  /* HAVE_ALLOCA_H */
+
 #if defined HAVE_TZFILE_H
 # include <tzfile.h>
 #endif	/* HAVE_TZFILE_H */


### PR DESCRIPTION
Some systems (MacOSX) warned us about this.

Also see man 3 alloca:
 "Normally, gcc(1) translates calls to alloca() with inlined code. This
 is not done when either the -ansi, -std=c89, -std=c99, or the
 -fno-builtin option is  given (and the header <alloca.h> is not
 included).  But beware!  By default the glibc version of <stdlib.h>
 includes <alloca.h> and that contains the line:
   #define alloca(size)   __builtin_alloca (size)
 with messy consequences if one has a private version of this function."
