### PR TITLE
New IATA timezones

### DIFF
--- a/iata.tzmap
+++ b/iata.tzmap
@@ -3550,6 +3550,7 @@ JSG	America/Los_Angeles
 JSH	Europe/Athens
 JSI	Europe/Athens
 JSJ	Asia/Harbin
+JSK	Asia/Tehran
 JSM	America/Argentina/Catamarca
 JSO	Europe/Stockholm
 JSP	Asia/Seoul
@@ -8452,6 +8453,7 @@ WYS	America/Denver
 WZQ	Asia/Kashgar
 XAB	Europe/Paris
 XAC	Europe/Paris
+XAI	Asia/Shanghai
 XAL	America/Hermosillo
 XAN	Europe/Paris
 XAP	America/Sao_Paulo


### PR DESCRIPTION
New entries from
https://raw.githubusercontent.com/opentraveldata/opentraveldata/master/data/IATA/archives/iata_airport_list_20180312.csv

Used https://time.is/ to look up timezones.