### PR TITLE
remove useless function

### DIFF
--- a/build-aux/yuck.c
+++ b/build-aux/yuck.c
@@ -146,16 +146,6 @@ error(const char *fmt, ...)
 	return;
 }
 
-static inline __attribute__((unused)) void*
-deconst(const void *cp)
-{
-	union {
-		const void *c;
-		void *p;
-	} tmp = {cp};
-	return tmp.p;
-}
-
 static inline __attribute__((always_inline)) unsigned int
 yfls(unsigned int x)
 {


### PR DESCRIPTION
Hi, I am Lanting Shen from Qihoo360 CodeSafe Team.
We found static function deconst is never been called. If this function is really not used, we can just remove it.