### PR TITLE
Fix dzone.012 test

### DIFF
--- a/test/dzone.012.clit
+++ b/test/dzone.012.clit
@@ -1,8 +1,9 @@
 #!/usr/bin/clitoris  ## -*- shell-script -*-
 
-$ dzone Europe/Berlin Australia/Sydney 08:00:00
-10:00:00+02:00	Europe/Berlin
-18:00:00+10:00	Australia/Sydney
+$ dzone UTC Europe/Moscow America/Bogota 08:00:00
+08:00:00+00:00	UTC
+11:00:00+03:00	Europe/Moscow
+03:00:00-05:00	America/Bogota
 $
 
 ## dzone.012.clit ends here


### PR DESCRIPTION
Since 3abf059a063acb7d0d7b673017e824a826a2173e
was meant to check time-only operation,
we cannot do the same as dzone.004.clit
but have to use timezones that do not have DST

Fixes issue #84