### PR TITLE
Update timezones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/iata.tzmap
+++ b/iata.tzmap
@@ -3341,7 +3341,7 @@ ISG	Asia/Tokyo
 ISI	Australia/Brisbane
 ISJ	America/Cancun
 ISK	Asia/Kolkata
-ISL	America/Anchorage
+ISL	Europe/Istanbul
 ISM	America/New_York
 ISN	America/Chicago
 ISO	America/New_York

--- a/iata.tzmap
+++ b/iata.tzmap
@@ -6730,6 +6730,7 @@ SAC	America/Los_Angeles
 SAD	America/Phoenix
 SAE	America/Godthab
 SAF	America/Denver
+SAG Asia/Kolkata
 SAH	Asia/Aden
 SAK	Atlantic/Reykjavik
 SAL	America/El_Salvador

--- a/iata.tzmap
+++ b/iata.tzmap
@@ -6730,7 +6730,7 @@ SAC	America/Los_Angeles
 SAD	America/Phoenix
 SAE	America/Godthab
 SAF	America/Denver
-SAG Asia/Kolkata
+SAG	Asia/Kolkata
 SAH	Asia/Aden
 SAK	Atlantic/Reykjavik
 SAL	America/El_Salvador


### PR DESCRIPTION
Changed ISL for Instanbul New Airport (see https://www.iata.org/policy/slots/Documents/slot_news/2018%20April%20news/iata-spec-ind-notif-ist.pdf)

Added SAG (Shirdi Airport, India)