### PR TITLE
docs: fix simple typo, uncomparable -> incomparable

### DIFF
--- a/src/dtest.c
+++ b/src/dtest.c
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 
 	/* just do the comparison */
 	if ((res = dt_dtcmp(d1, d2)) == -2) {
-		/* uncomparable */
+		/* incomparable */
 		res = 3;
 	} else if (argi->cmp_flag) {
 		switch (res) {


### PR DESCRIPTION
There is a small typo in src/dtest.c.

Should read `incomparable` rather than `uncomparable`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md