### PR TITLE
doc, fix typos

### DIFF
--- a/info/Makefile.am
+++ b/info/Makefile.am
@@ -1,5 +1,5 @@
 # Help the Developers and yourself.  Just use the C locale and settings
-# for the compilation. They can still be overriden by make LANG=<whatever>
+# for the compilation. They can still be overridden by make LANG=<whatever>
 # but that is general a not very good idea
 LANG=C
 LC_ALL=C

--- a/lib/date-core.c
+++ b/lib/date-core.c
@@ -105,7 +105,7 @@ struct __md_s {
 /* bizda definitions, reference dates */
 static __attribute__((unused)) const char *bizda_ult[] = {"ultimo", "ult"};
 
-/* arithmetics helpers */
+/* arithmetic helpers */
 static inline unsigned int
 __uimod(signed int x, signed int m)
 {

--- a/lib/time-core.c
+++ b/lib/time-core.c
@@ -208,7 +208,7 @@ dt_strft(char *restrict buf, size_t bsz, const char *fmt, struct dt_t_s that)
 	return bp - buf;
 }
 
-/* arithmetics helpers */
+/* arithmetic helpers */
 struct divrem_s {
 	signed int div;
 	unsigned int rem;

--- a/lib/yd.c
+++ b/lib/yd.c
@@ -249,7 +249,7 @@ static inline __attribute__((pure)) dt_dow_t
 __get_jan01_wday(unsigned int year)
 {
 /* get the weekday of jan01 in YEAR
- * using the 28y cycle thats valid till the year 2399
+ * using the 28y cycle that's valid till the year 2399
  * 1920 = 16 mod 28 */
 #if !defined WITH_FAST_ARITH
 	if (UNLIKELY(year > 2100U ||
@@ -273,7 +273,7 @@ static inline __attribute__((const)) dt_dow_t
 __get_jan01_wday(unsigned int year)
 {
 /* get the weekday of jan01 in YEAR
- * using the 28y cycle thats valid till the year 2399
+ * using the 28y cycle that's valid till the year 2399
  * 1920 = 16 mod 28
  * switch variant */
 # define M	(DT_MONDAY)

--- a/lib/ywd.c
+++ b/lib/ywd.c
@@ -495,7 +495,7 @@ __make_ywd_c(unsigned int y, unsigned int c, dt_dow_t w, unsigned int cc)
 			;
 		} else if (hang > 0 && u < DT_SUNDAY && u < j01) {
 			/* n-th W in the year is n-th week,
-			 * in this case the year doesnt start on sunday */
+			 * in this case the year doesn't start on sunday */
 			;
 		} else if (hang <= 0 && (u >= j01 || u == DT_SUNDAY)) {
 			/* n-th W in the year is n-th week */

--- a/src/dround.c
+++ b/src/dround.c
@@ -931,21 +931,21 @@ cannot parse duration/rounding string `%s'", st.istr);\
 					}
 					break;
 				case DT_DURMO:
-					/* make a millenium the next milestone */
+					/* make a millennium the next milestone */
 					if (!LAST_DUR.d.dv ||
 					    12000 % LAST_DUR.d.dv) {
 						goto nococl;
 					}
 					break;
 				case DT_DURQU:
-					/* make a millenium the next milestone */
+					/* make a millennium the next milestone */
 					if (!LAST_DUR.d.dv ||
 					    4000 % LAST_DUR.d.dv) {
 						goto nococl;
 					}
 					break;
 				case DT_DURYR:
-					/* make a millenium the next milestone */
+					/* make a millennium the next milestone */
 					if (!LAST_DUR.d.dv ||
 					    1000 % LAST_DUR.d.dv) {
 						goto nococl;

--- a/src/dround.yuck
+++ b/src/dround.yuck
@@ -48,7 +48,7 @@ that is less (older) than the specified date or datetime.
     will yield  2019-01-28T12:00:00
 
 The superdivision of years are millennia, i.e. there's 1000 years,
-500 biennia, 100 decades, etc. in a millenium.
+500 biennia, 100 decades, etc. in a millennium.
 
 
 Multiple RNDSPECs are evaluated left to right.

--- a/src/dt-io.c
+++ b/src/dt-io.c
@@ -534,7 +534,7 @@ calc_grep_atom(const char *fmt)
 post_snarf:
 	if (res.needle == 0 && (res.pl.off_min || res.pl.off_max)) {
 		if ((res.pl.flags & ~(GRPATM_DIGITS | GRPATM_ORDINALS)) == 0) {
-			/* ah, only digits, thats good */
+			/* ah, only digits, that's good */
 			int8_t tmp = (int8_t)-res.pl.off_min;
 
 			/* swap-invert min and max */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,5 @@
 # Help the Developers and yourself. Just use the C locale and settings
-# for the compilation. They can still be overriden by make LANG=<whatever>
+# for the compilation. They can still be overridden by make LANG=<whatever>
 # but that is general a not very good idea
 include $(top_builddir)/version.mk
 


### PR DESCRIPTION
Found via `codespell -S build-aux,./data/locale -L ser,nd,fof,skipp`